### PR TITLE
Cleanup TSocketTransport and related code

### DIFF
--- a/lib/dart/lib/src/browser/t_web_socket.dart
+++ b/lib/dart/lib/src/browser/t_web_socket.dart
@@ -58,7 +58,7 @@ class TWebSocket implements TSocket {
   bool get isClosed =>
       _socket == null || _socket.readyState == WebSocket.CLOSED;
 
-  Future open() async {
+  Future open() {
     if (!isClosed) {
       throw new TTransportError(
           TTransportErrorType.ALREADY_OPEN, 'Socket already connected');
@@ -69,11 +69,16 @@ class TWebSocket implements TSocket {
     _socket.onOpen.listen(_onOpen);
     _socket.onClose.listen(_onClose);
     _socket.onMessage.listen(_onMessage);
+
+    return _socket.onOpen.first;
   }
 
-  Future close() async {
+  Future close() {
     if (_socket != null) {
       _socket.close();
+      return _socket.onClose.first;
+    } else {
+      return new Future.value();
     }
   }
 

--- a/lib/dart/lib/src/console/t_web_socket.dart
+++ b/lib/dart/lib/src/console/t_web_socket.dart
@@ -19,9 +19,7 @@ library thrift.src.console;
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data' show Uint8List;
 
-import 'package:crypto/crypto.dart' show CryptoUtils;
 import 'package:thrift/thrift.dart';
 
 /// A [TSocket] backed by a [WebSocket] from dart:io
@@ -32,12 +30,10 @@ class TWebSocket implements TSocket {
   final StreamController<Object> _onErrorController;
   Stream<Object> get onError => _onErrorController.stream;
 
-  final StreamController<Uint8List> _onMessageController;
-  Stream<Uint8List> get onMessage => _onMessageController.stream;
+  final StreamController<String> _onMessageController;
+  Stream<String> get onMessage => _onMessageController.stream;
 
-  final List<Completer<Uint8List>> _completers = [];
-
-  TWebSocket(WebSocket socket, {this.isServer: true})
+  TWebSocket(WebSocket socket)
       : _onStateController = new StreamController.broadcast(),
         _onErrorController = new StreamController.broadcast(),
         _onMessageController = new StreamController.broadcast() {
@@ -48,8 +44,6 @@ class TWebSocket implements TSocket {
     _socket = socket;
     _socket.listen(_onMessage, onError: _onError, onDone: close);
   }
-
-  final bool isServer;
 
   WebSocket _socket;
 
@@ -67,45 +61,15 @@ class TWebSocket implements TSocket {
       _socket = null;
     }
 
-    for (var completer in _completers) {
-      completer.completeError(new StateError('The socket has closed'));
-    }
-    _completers.clear();
-
     _onStateController.add(TSocketState.CLOSED);
   }
 
-  Future<Uint8List> send(Uint8List data) async {
-    Future result;
-    if (isServer) {
-      result = new Future.value();
-    } else {
-      // if we are a client, then we expect a result
-      Completer<Uint8List> completer = new Completer();
-      _completers.add(completer);
-      result = completer.future;
-    }
-
-    _socket.add(CryptoUtils.bytesToBase64(data));
-
-    return result;
+  void send(String data) {
+    _socket.add(data);
   }
 
-  void _onMessage(Object message) {
-    Uint8List data;
-
-    try {
-      data = new Uint8List.fromList(CryptoUtils.base64StringToBytes(message));
-    } on FormatException catch (_) {
-      _onErrorController
-          .add(new UnsupportedError('Expected a Base 64 encoded string.'));
-    }
-
-    if (!_completers.isEmpty) {
-      _completers.removeAt(0).complete(data);
-    }
-
-    _onMessageController.add(data);
+  void _onMessage(String message) {
+    _onMessageController.add(message);
   }
 
   void _onError(Object error) {

--- a/lib/dart/lib/src/transport/t_socket.dart
+++ b/lib/dart/lib/src/transport/t_socket.dart
@@ -24,7 +24,7 @@ abstract class TSocket {
 
   Stream<String> get onError;
 
-  Stream<String> get onMessage;
+  Stream<Uint8List> get onMessage;
 
   bool get isOpen;
 
@@ -34,5 +34,5 @@ abstract class TSocket {
 
   Future close();
 
-  void send(String data);
+  void send(Uint8List data);
 }

--- a/lib/dart/lib/src/transport/t_socket.dart
+++ b/lib/dart/lib/src/transport/t_socket.dart
@@ -24,7 +24,7 @@ abstract class TSocket {
 
   Stream<String> get onError;
 
-  Stream<Uint8List> get onMessage;
+  Stream<String> get onMessage;
 
   bool get isOpen;
 
@@ -34,5 +34,5 @@ abstract class TSocket {
 
   Future close();
 
-  Future<Uint8List> send(Uint8List data);
+  void send(String data);
 }

--- a/lib/dart/test/transport/t_socket_transport_test.dart
+++ b/lib/dart/test/transport/t_socket_transport_test.dart
@@ -36,7 +36,7 @@ void main() {
       await new Future.value();
 
       expect(socket.sendPayload, isNotNull);
-      expect(socket.sendPayload, requestBase64);
+      expect(socket.sendPayload, requestBytes);
 
       // simulate a response
       socket.receiveFakeMessage(responseBase64);
@@ -88,7 +88,7 @@ void main() {
       await new Future.value();
 
       expect(socket.sendPayload, isNotNull);
-      expect(socket.sendPayload, responseBase64);
+      expect(socket.sendPayload, responseBytes);
     });
   }, timeout: new Timeout(new Duration(seconds: 1)));
 
@@ -103,8 +103,8 @@ class FakeSocket extends TSocket {
   final StreamController<Object> _onErrorController;
   Stream<Object> get onError => _onErrorController.stream;
 
-  final StreamController<String> _onMessageController;
-  Stream<String> get onMessage => _onMessageController.stream;
+  final StreamController<Uint8List> _onMessageController;
+  Stream<Uint8List> get onMessage => _onMessageController.stream;
 
   FakeSocket()
       : _onStateController = new StreamController.broadcast(),
@@ -127,18 +127,20 @@ class FakeSocket extends TSocket {
     _onStateController.add(TSocketState.CLOSED);
   }
 
-  String _sendPayload;
-  String get sendPayload => _sendPayload;
+  Uint8List _sendPayload;
+  Uint8List get sendPayload => _sendPayload;
 
-  void send(String data) {
+  void send(Uint8List data) {
     if (!isOpen) throw new StateError("The socket is not open");
 
     _sendPayload = data;
   }
 
-  void receiveFakeMessage(String message) {
+  void receiveFakeMessage(String base64) {
     if (!isOpen) throw new StateError("The socket is not open");
 
+    var message =
+        new Uint8List.fromList(CryptoUtils.base64StringToBytes(base64));
     _onMessageController.add(message);
   }
 

--- a/tutorial/dart/client/web/client.dart
+++ b/tutorial/dart/client/web/client.dart
@@ -47,7 +47,7 @@ class CalculatorUI {
   }
 
   void _initConnection() {
-    _transport = new TSocketTransport(
+    _transport = new TClientSocketTransport(
         new TWebSocket(Uri.parse('ws://127.0.0.1:9090/ws')));
     TProtocol protocol = new TJsonProtocol(_transport);
     _transport.open();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/THRIFT-3299
- Moved completer logic from WebSocket implementations to transport.  
- Split TSocketTransport into TClientSocketTransport and TServerSocketTransport to cleanup some conditional logic.
- Added a TODO to call out the need to correlate socket requests + responses

@tylertreat-wf
@evanweible-wf
@stevenosborne-wf
