### PR TITLE
Dart tooling and cleanup

### DIFF
--- a/lib/dart/.gitignore
+++ b/lib/dart/.gitignore
@@ -2,3 +2,4 @@
 packages
 .pub/
 pubspec.lock
+/coverage/

--- a/lib/dart/LICENSE_HEADER
+++ b/lib/dart/LICENSE_HEADER
@@ -1,0 +1,16 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.

--- a/lib/dart/lib/src/transport/t_message_reader.dart
+++ b/lib/dart/lib/src/transport/t_message_reader.dart
@@ -35,12 +35,10 @@ class TMessageReader {
 
     return message;
   }
-
 }
 
 /// An internal class used to support [TMessageReader].
 class _TMessageReaderTransport extends TTransport {
-
   _TMessageReaderTransport();
 
   Iterator<int> _readIterator;

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -6,11 +6,14 @@ author: Mark Erickson <mark.erickson@workiva.com>
 homepage: https://github.com/apache/thrift
 documentation: https://github.com/apache/thrift
 environment:
-  sdk: ^1.12.0
+  sdk: ">=1.12.0 <2.0.0"
 dependencies:
-  crypto: ^0.9.0
-  http: ^0.11.3
-  logging: ^0.11.0
+  crypto: "^0.9.0"
+  http: "^0.11.3"
+  logging: "^0.11.0"
 dev_dependencies:
-  mockito: ^0.11.0
-  test: ^0.12.0
+  coverage: "^0.7.2"
+  dart_dev: "^1.0.1"
+  dart_style: "^0.2.0"
+  mockito: "^0.11.0"
+  test: "^0.12.0"

--- a/lib/dart/test/protocol/t_protocol_test.dart
+++ b/lib/dart/test/protocol/t_protocol_test.dart
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 library thrift.test.transport.t_json_protocol_test;
 
 import 'dart:typed_data' show Uint8List;
@@ -6,7 +23,6 @@ import 'package:test/test.dart';
 import 'package:thrift/thrift.dart';
 
 void main() {
-
   final message = new TMessage('my message', TMessageType.ONEWAY, 123);
 
   TProtocol protocol;
@@ -192,7 +208,7 @@ void main() {
 
     test('Test string', () async {
       var input = 'There are only two hard things in computer science: '
-                  'cache invalidation, naming things, and off-by-one errors.';
+          'cache invalidation, naming things, and off-by-one errors.';
 
       protocol.writeString(input);
       protocol.writeMessageEnd();
@@ -238,5 +254,4 @@ void main() {
 
     group('shared tests', sharedTests);
   });
-
 }

--- a/lib/dart/test/transport/t_http_transport_test.dart
+++ b/lib/dart/test/transport/t_http_transport_test.dart
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 library thrift.test.transport.t_socket_transport_test;
 
 import 'dart:async';
@@ -14,7 +31,6 @@ import 'package:test/test.dart';
 import 'package:thrift/thrift.dart';
 
 void main() {
-
   const utf8Codec = const Utf8Codec();
 
   FakeHttpClient client;
@@ -36,8 +52,8 @@ void main() {
 
     expect(client.postRequest, isNotEmpty);
 
-    var requestText = utf8Codec.decode(
-        CryptoUtils.base64StringToBytes(client.postRequest));
+    var requestText =
+        utf8Codec.decode(CryptoUtils.base64StringToBytes(client.postRequest));
     expect(requestText, expectedText);
   });
 
@@ -59,17 +75,14 @@ void main() {
     var bufferText = utf8Codec.decode(buffer);
     expect(bufferText, expectedText);
   });
-
 }
 
-
 class FakeHttpClient implements Client {
-
   String postResponse = "";
   String postRequest = "";
 
-  Future<Response> post(url, {Map<String, String> headers, body,
-      Encoding encoding}) async {
+  Future<Response> post(url,
+      {Map<String, String> headers, body, Encoding encoding}) async {
     postRequest = body;
     return new Response(postResponse, 200);
   }
@@ -80,11 +93,13 @@ class FakeHttpClient implements Client {
   Future<Response> get(url, {Map<String, String> headers}) =>
       throw new UnimplementedError();
 
-  Future<Response> put(url, {Map<String, String> headers, body,
-      Encoding encoding}) => throw new UnimplementedError();
+  Future<Response> put(url,
+          {Map<String, String> headers, body, Encoding encoding}) =>
+      throw new UnimplementedError();
 
-  Future<Response> patch(url, {Map<String, String> headers, body,
-      Encoding encoding}) => throw new UnimplementedError();
+  Future<Response> patch(url,
+          {Map<String, String> headers, body, Encoding encoding}) =>
+      throw new UnimplementedError();
 
   Future<Response> delete(url, {Map<String, String> headers}) =>
       throw new UnimplementedError();
@@ -99,5 +114,4 @@ class FakeHttpClient implements Client {
       throw new UnimplementedError();
 
   void close() => throw new UnimplementedError();
-
 }

--- a/lib/dart/test/transport/t_socket_transport_test.dart
+++ b/lib/dart/test/transport/t_socket_transport_test.dart
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 library thrift.test.transport.t_socket_transport_test;
 
 import 'dart:async';
@@ -10,7 +27,6 @@ import 'package:test/test.dart';
 import 'package:thrift/thrift.dart';
 
 void main() {
-
   const utf8Codec = const Utf8Codec();
 
   final requestText = 'my test request';
@@ -59,7 +75,8 @@ void main() {
 
       FakeProtocolFactory protocolFactory = new FakeProtocolFactory();
       protocolFactory.message = new TMessage("foo", TMessageType.CALL, 123);
-      var transport = new TClientSocketTransport(socket, protocolFactory, responseTimeout: Duration.ZERO);
+      var transport = new TClientSocketTransport(socket, protocolFactory,
+          responseTimeout: Duration.ZERO);
       transport.writeAll(requestBytes);
 
       Future responseReady = transport.flush();
@@ -109,12 +126,9 @@ void main() {
       expect(socket.sendPayload, responseBytes);
     });
   }, timeout: new Timeout(new Duration(seconds: 1)));
-
 }
 
-
 class FakeSocket extends TSocket {
-
   final StreamController<TSocketState> _onStateController;
   Stream<TSocketState> get onState => _onStateController.stream;
 
@@ -161,26 +175,20 @@ class FakeSocket extends TSocket {
         new Uint8List.fromList(CryptoUtils.base64StringToBytes(base64));
     _onMessageController.add(message);
   }
-
 }
 
-
 class FakeProtocolFactory implements TProtocolFactory {
-
   FakeProtocolFactory();
 
   TMessage message;
 
   getProtocol(TTransport transport) => new FakeProtocol(message);
-
 }
 
 class FakeProtocol extends Mock implements TProtocol {
-
   FakeProtocol(this._message);
 
   TMessage _message;
 
   readMessageBegin() => _message;
-
 }

--- a/lib/dart/tool/dev.dart
+++ b/lib/dart/tool/dev.dart
@@ -15,32 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-library thrift.test.t_application_error_test;
+library tool.dev;
 
-import 'package:test/test.dart';
-import 'package:thrift/thrift.dart';
+import 'package:dart_dev/dart_dev.dart' show dev, config;
 
-void main() {
-  TProtocol protocol;
+main(List<String> args) async {
+  // https://github.com/Workiva/dart_dev
 
-  setUp(() {
-    protocol = new TBinaryProtocol(new TBufferedTransport());
-  });
+  var directories = ['lib/', 'test/', 'tool/'];
+  config.analyze.entryPoints = directories;
+  config.format.directories = directories;
+  config.copyLicense
+    ..licensePath = 'LICENSE_HEADER'
+    ..directories = directories;
 
-  test('Write and read an application error', () {
-    var expectedType = TApplicationErrorType.INTERNAL_ERROR;
-    var expectedMessage = 'test error message';
-
-    TApplicationError error =
-        new TApplicationError(expectedType, expectedMessage);
-    error.write(protocol);
-
-    protocol.transport.flush();
-
-    TApplicationError subject = TApplicationError.read(protocol);
-
-    expect(subject, isNotNull);
-    expect(subject.type, expectedType);
-    expect(subject.message, expectedMessage);
-  });
+  await dev(args);
 }


### PR DESCRIPTION
Added dart_dev and ran the code formatter and added license headers to all source files.

This also means we can run tests, coverage, and static analyzer via dart_dev now.

@markerickson-wf 
