### PR TITLE
THRIFT-3468 Match type in TSocketTransport onError handler to stream type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ erl_crash.dump
 /lib/d/test/serialization_benchmark
 /lib/d/test/transport_test
 /lib/d/unittest/
+/lib/dart/coverage
 /lib/dart/**/.packages
 /lib/dart/**/packages
 /lib/dart/**/.pub/

--- a/lib/dart/lib/src/transport/t_socket_transport.dart
+++ b/lib/dart/lib/src/transport/t_socket_transport.dart
@@ -28,7 +28,7 @@ part of thrift;
 ///
 /// Adapted from the JS WebSocket transport.
 abstract class TSocketTransport extends TBufferedTransport {
-  final Logger log = new Logger('thrift.TSocketTransport');
+  final Logger logger = new Logger('thrift.TSocketTransport');
 
   final TSocket socket;
 
@@ -38,7 +38,7 @@ abstract class TSocketTransport extends TBufferedTransport {
       throw new ArgumentError.notNull('socket');
     }
 
-    socket.onError.listen((String e) => log.warning(e));
+    socket.onError.listen((e) => logger.warning(e));
     socket.onMessage.listen(handleIncomingMessage);
   }
 


### PR DESCRIPTION
Change the type of the onError handler to match the stream's type (which is untyped Object).

Also ignore the test coverage output directory, for the dart lib.

https://issues.apache.org/jira/browse/THRIFT-3468

@evanweible-wf
@tylertreat-wf
@stevenosborne-wf
